### PR TITLE
Teach WillyBot to adapt routes after deaths

### DIFF
--- a/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
+++ b/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Zen.Z80.Processor;
 
@@ -268,7 +269,7 @@ public class RoutePlanner
 
         foreach (var deathCell in _deathCells)
         {
-            var distance = System.Math.Abs(deathCell.X - cell.Item1) + System.Math.Abs(deathCell.Y - cell.Item2);
+            var distance = Math.Abs(deathCell.X - cell.Item1) + Math.Abs(deathCell.Y - cell.Item2);
 
             if (distance <= 2)
             {

--- a/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
+++ b/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
@@ -9,9 +9,12 @@ public class RoutePlanner
 
     private readonly PriorityQueue<(int X, int Y, List<Move> Moves, HashSet<(int X, int Y)> Keys, HashSet<(int X, int Y)> Visited, int Steps), int> _queue = new();
     
-    public RoutePlanner(int level, Interface @interface)
+    private readonly HashSet<(int X, int Y)> _deathCells;
+
+    public RoutePlanner(int level, Interface @interface, IEnumerable<(int X, int Y)> deathCells = null)
     {
         _levelData = new LevelData(level, @interface);
+        _deathCells = deathCells == null ? [] : [..deathCells];
     }
 
     public void Initialise()
@@ -46,7 +49,9 @@ public class RoutePlanner
                     continue;
                 }
 
-                _queue.Enqueue((move.X, move.Y, [..node.Moves, move.Move], node.Keys, [..node.Visited, (move.X, move.Y)], node.Steps + 1), node.Steps + 1);
+                var penalty = GetDeathPenalty(move.X, move.Y);
+
+                _queue.Enqueue((move.X, move.Y, [..node.Moves, move.Move], [..node.Keys], [..node.Visited, (move.X, move.Y)], node.Steps + 1), node.Steps + 1 + penalty);
             }
         }
 
@@ -115,7 +120,7 @@ public class RoutePlanner
 
         if (TryWalk(x, y, 2))
         {
-            moves.Add((Move.Left, x + 2, y));
+            moves.Add((Move.Right, x + 2, y));
         }
 
         var jump = TryJump(x, y, -2);
@@ -129,7 +134,7 @@ public class RoutePlanner
 
         if (jump.Safe)
         {
-            moves.Add((Move.UpLeft, jump.X, jump.Y));
+            moves.Add((Move.UpRight, jump.X, jump.Y));
         }
 
         return moves;
@@ -245,6 +250,38 @@ public class RoutePlanner
         }
 
         return true;
+    }
+
+    private int GetDeathPenalty(int x, int y)
+    {
+        if (_deathCells.Count == 0)
+        {
+            return 0;
+        }
+
+        var cell = (x / 8, y / 8);
+
+        if (_deathCells.Contains(cell))
+        {
+            return 10000;
+        }
+
+        foreach (var deathCell in _deathCells)
+        {
+            var distance = System.Math.Abs(deathCell.X - cell.Item1) + System.Math.Abs(deathCell.Y - cell.Item2);
+
+            if (distance <= 2)
+            {
+                return 1000;
+            }
+
+            if (distance <= 4)
+            {
+                return 250;
+            }
+        }
+
+        return 0;
     }
 
     private bool CheckOpen(int x, int y)

--- a/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/WillyBot.cs
+++ b/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/WillyBot.cs
@@ -13,6 +13,8 @@ public class WillyBot : IProcessorHook
     private readonly Queue<Move> _route = new();
 
     private Move _move;
+
+    private readonly Dictionary<int, HashSet<(int X, int Y)>> _deathsByLevel = new();
     
     public bool Activate(State state)
     {
@@ -36,6 +38,8 @@ public class WillyBot : IProcessorHook
             case 0x8D07:
             case 0x88FF:
                 // Dead
+
+                LearnFromDeath(@interface);
 
                 RestartLevel();
                 
@@ -121,7 +125,7 @@ public class WillyBot : IProcessorHook
                 
                 var grounded = @interface.ReadFromMemory(0x806B) == 0;
 
-                if (grounded)
+                if (grounded && _route.Count > 0)
                 {
                     _move = _route.Dequeue();
                 }
@@ -132,7 +136,7 @@ public class WillyBot : IProcessorHook
 
     private void StartLevel(Interface @interface)
     {
-        _routePlanner = new RoutePlanner(_level, @interface);
+        _routePlanner = new RoutePlanner(_level, @interface, GetDeathCells(_level));
         
         _routePlanner.Initialise();
         
@@ -142,7 +146,47 @@ public class WillyBot : IProcessorHook
     private void RestartLevel()
     {
         _route.Clear();
-        
-        _routePlanner.GetNextRoute().ForEach(m => _route.Enqueue(m));
+
+        var route = _routePlanner.GetNextRoute();
+
+        if (route == null)
+        {
+            return;
+        }
+
+        route.ForEach(m => _route.Enqueue(m));
+    }
+
+    private void LearnFromDeath(Interface @interface)
+    {
+        var cellPointer = @interface.ReadFromMemory(0x806C) + (@interface.ReadFromMemory(0x806D) << 8);
+
+        if (cellPointer < 0x5C00)
+        {
+            return;
+        }
+
+        var cellOffset = cellPointer - 0x5C00;
+
+        var x = cellOffset % 32;
+        var y = @interface.ReadFromMemory(0x8068) / 2 / 8;
+
+        if (!_deathsByLevel.TryGetValue(_level, out var cells))
+        {
+            cells = [];
+            _deathsByLevel[_level] = cells;
+        }
+
+        cells.Add((x, y));
+    }
+
+    private IEnumerable<(int X, int Y)> GetDeathCells(int level)
+    {
+        if (_deathsByLevel.TryGetValue(level, out var cells))
+        {
+            return cells;
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
### Motivation
- Enable the Manic Miner solver to learn from Willy’s deaths so future plans avoid previously fatal locations and nearby areas.
- Reduce repeated failures by biasing the pathfinder away from cells that killed Willy and by fixing route/action mapping bugs that caused incorrect inputs.

### Description
- Record per-level death cells in `WillyBot` with a new `_deathsByLevel` map and a `LearnFromDeath` helper that reads the game cell pointer and stores the death coordinate, and expose them via `GetDeathCells` when starting a level.
- Pass learned death cells into `RoutePlanner` constructor and store them in a `_deathCells` set, then apply `GetDeathPenalty` to increase queue priority cost for exact death cells and nearby cells so the planner prefers safer routes.
- Fix route generation tagging errors by correctly adding `Move.Right` for right-walks and `Move.UpRight` for right-side jumps, and add guards so `WillyBot` won’t dequeue from an empty route and will handle a `null` route from the planner safely.

### Testing
- Attempted to run `dotnet build src/Zen.sln`, which failed in this environment because `dotnet` is not installed (no further automated tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5049efbc8322aca33c173e7d6f18)