### PR TITLE
ManicMiner: route planning refactor with key bitmasking and death-avoidance; WillyBot learns death locations

### DIFF
--- a/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
+++ b/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
@@ -7,50 +7,93 @@ public class RoutePlanner
 {
     private readonly LevelData _levelData;
 
-    private readonly PriorityQueue<(int X, int Y, List<Move> Moves, HashSet<(int X, int Y)> Keys, HashSet<(int X, int Y)> Visited, int Steps), int> _queue = new();
-    
-    public RoutePlanner(int level, Interface @interface)
+    private readonly PriorityQueue<(int X, int Y, List<Move> Moves, int KeyMask, int Cost), int> _queue = new();
+
+    private readonly Dictionary<(int X, int Y), int> _keyBits = new();
+
+    private readonly Dictionary<(int X, int Y, int KeyMask), int> _bestCosts = new();
+
+    private readonly HashSet<(int X, int Y)> _deathCells;
+
+    private readonly int _allKeysMask;
+
+    public RoutePlanner(int level, Interface @interface, IEnumerable<(int X, int Y)> deathCells = null)
     {
         _levelData = new LevelData(level, @interface);
+        _deathCells = deathCells == null ? [] : [..deathCells];
+
+        for (var i = 0; i < _levelData.Keys.Count; i++)
+        {
+            _keyBits[_levelData.Keys[i]] = 1 << i;
+        }
+
+        _allKeysMask = (1 << _levelData.Keys.Count) - 1;
     }
 
     public void Initialise()
     {
-        _queue.Enqueue((_levelData.Start.X * 8, _levelData.Start.Y * 8, [], [], [], 0), 0);
+        var startX = _levelData.Start.X * 8;
+        var startY = _levelData.Start.Y * 8;
+
+        _queue.Enqueue((startX, startY, [], 0, 0), 0);
+        _bestCosts[(startX, startY, 0)] = 0;
     }
 
     public List<Move> GetNextRoute()
     {
         while (_queue.TryDequeue(out var node, out _))
         {
-            if (IsComplete(node))
+            var nodeState = (node.X, node.Y, node.KeyMask);
+
+            if (_bestCosts.TryGetValue(nodeState, out var bestCost) && node.Cost > bestCost)
+            {
+                continue;
+            }
+
+            var keyMask = AddKey(node.KeyMask, node.X, node.Y);
+
+            if (IsComplete(node.X, node.Y, keyMask))
             {
                 return node.Moves;
             }
 
-            var key = CheckKey(node.X, node.Y);
-
-            if (key.X != -1)
-            {
-                node.Keys.Add((key.X, key.Y));
-            }
-
             var moves = GetMoves(node.X, node.Y);
-            
+
             foreach (var move in moves)
             {
-                var visited = node.Visited.Contains((move.X, move.Y));
+                var penalty = GetDeathPenalty(move.X, move.Y);
+                var cost = node.Cost + 1 + penalty;
+                var nextState = (move.X, move.Y, keyMask);
 
-                if (visited)
+                if (_bestCosts.TryGetValue(nextState, out bestCost) && bestCost <= cost)
                 {
                     continue;
                 }
 
-                _queue.Enqueue((move.X, move.Y, [..node.Moves, move.Move], node.Keys, [..node.Visited, (move.X, move.Y)], node.Steps + 1), node.Steps + 1);
+                _bestCosts[nextState] = cost;
+
+                _queue.Enqueue((move.X, move.Y, [..node.Moves, move.Move], keyMask, cost), cost);
             }
         }
 
         return null;
+    }
+
+    private int AddKey(int keyMask, int x, int y)
+    {
+        var key = CheckKey(x, y);
+
+        if (key.X == -1)
+        {
+            return keyMask;
+        }
+
+        if (_keyBits.TryGetValue((key.X, key.Y), out var bit))
+        {
+            return keyMask | bit;
+        }
+
+        return keyMask;
     }
 
     private (int X, int Y) CheckKey(int x, int y)
@@ -59,49 +102,45 @@ public class RoutePlanner
 
         var cellY = y / 8;
 
-        if (_levelData.Keys.Contains((cellX, cellY)))
+        if (_keyBits.ContainsKey((cellX, cellY)))
         {
             return (cellX, cellY);
         }
 
-        if (_levelData.Keys.Contains((cellX, cellY + 1)))
+        if (_keyBits.ContainsKey((cellX, cellY + 1)))
         {
-            return (cellX, cellY);
+            return (cellX, cellY + 1);
         }
 
         if (x % 8 != 0)
         {
-            if (_levelData.Keys.Contains((cellX + 1, cellY)))
+            if (_keyBits.ContainsKey((cellX + 1, cellY)))
             {
                 return (cellX + 1, cellY);
             }
 
-            if (_levelData.Keys.Contains((cellX + 1, cellY + 1)))
+            if (_keyBits.ContainsKey((cellX + 1, cellY + 1)))
             {
-                return (cellX + 1, cellY);
+                return (cellX + 1, cellY + 1);
             }
         }
 
         return (-1, -1);
     }
 
-    private bool IsComplete((int X, int Y, List<Move> Moves, HashSet<(int X, int Y)> Keys, HashSet<(int X, int Y)> Visited, int Steps) node)
+    private bool IsComplete(int x, int y, int keyMask)
     {
-        if (node.Keys.Count < _levelData.Keys.Count)
+        if (keyMask != _allKeysMask)
         {
             return false;
         }
 
-        var x = node.X / 8;
+        var cellX = x / 8;
 
-        var y = node.Y / 8;
+        var cellY = y / 8;
 
-        if (x >= _levelData.End.X && x <= _levelData.End.X + 1 && y >= _levelData.End.Y && y <= _levelData.End.Y + 1)
-        {
-            return true;
-        }
-
-        return false;
+        return cellX >= _levelData.End.X && cellX <= _levelData.End.X + 1 &&
+               cellY >= _levelData.End.Y && cellY <= _levelData.End.Y + 1;
     }
 
     private List<(Move Move, int X, int Y)> GetMoves(int x, int y)
@@ -115,7 +154,7 @@ public class RoutePlanner
 
         if (TryWalk(x, y, 2))
         {
-            moves.Add((Move.Left, x + 2, y));
+            moves.Add((Move.Right, x + 2, y));
         }
 
         var jump = TryJump(x, y, -2);
@@ -129,7 +168,7 @@ public class RoutePlanner
 
         if (jump.Safe)
         {
-            moves.Add((Move.UpLeft, jump.X, jump.Y));
+            moves.Add((Move.UpRight, jump.X, jump.Y));
         }
 
         return moves;
@@ -138,7 +177,7 @@ public class RoutePlanner
     private bool TryWalk(int x, int y, int dX)
     {
         x += dX;
-        
+
         if (x < 8 || x > 238)
         {
             return false;
@@ -150,12 +189,12 @@ public class RoutePlanner
     private (bool Safe, int X, int Y) TryJump(int x, int y, int dX)
     {
         var velocities = new[] {-4, -4, -3, -3, -2, -2, -1, -1, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
-        
+
         for (var i = 0; i < velocities.Length; i++)
         {
             var velocity = velocities[i];
-            
-            if (! CheckSafe(x + dX, y + velocity))
+
+            if (!CheckSafe(x + dX, y + velocity))
             {
                 return (false, -1, -1);
             }
@@ -176,9 +215,9 @@ public class RoutePlanner
             }
         }
 
-        while (! CheckLanded(x, y))
+        while (!CheckLanded(x, y))
         {
-            if (! CheckSafe(x, y))
+            if (!CheckSafe(x, y))
             {
                 return (false, -1, -1);
             }
@@ -245,6 +284,38 @@ public class RoutePlanner
         }
 
         return true;
+    }
+
+    private int GetDeathPenalty(int x, int y)
+    {
+        if (_deathCells.Count == 0)
+        {
+            return 0;
+        }
+
+        var cell = (x / 8, y / 8);
+
+        if (_deathCells.Contains(cell))
+        {
+            return 10000;
+        }
+
+        foreach (var deathCell in _deathCells)
+        {
+            var distance = System.Math.Abs(deathCell.X - cell.Item1) + System.Math.Abs(deathCell.Y - cell.Item2);
+
+            if (distance <= 2)
+            {
+                return 1000;
+            }
+
+            if (distance <= 4)
+            {
+                return 250;
+            }
+        }
+
+        return 0;
     }
 
     private bool CheckOpen(int x, int y)

--- a/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
+++ b/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/RoutePlanner.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Zen.Z80.Processor;
 
@@ -302,7 +303,7 @@ public class RoutePlanner
 
         foreach (var deathCell in _deathCells)
         {
-            var distance = System.Math.Abs(deathCell.X - cell.Item1) + System.Math.Abs(deathCell.Y - cell.Item2);
+            var distance = Math.Abs(deathCell.X - cell.Item1) + Math.Abs(deathCell.Y - cell.Item2);
 
             if (distance <= 2)
             {

--- a/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/WillyBot.cs
+++ b/src/Zen.Desktop.Host/ProcessorHooks/ManicMiner/WillyBot.cs
@@ -13,6 +13,8 @@ public class WillyBot : IProcessorHook
     private readonly Queue<Move> _route = new();
 
     private Move _move;
+
+    private readonly Dictionary<int, HashSet<(int X, int Y)>> _deathsByLevel = new();
     
     public bool Activate(State state)
     {
@@ -36,6 +38,8 @@ public class WillyBot : IProcessorHook
             case 0x8D07:
             case 0x88FF:
                 // Dead
+
+                LearnFromDeath(@interface);
 
                 RestartLevel();
                 
@@ -121,7 +125,7 @@ public class WillyBot : IProcessorHook
                 
                 var grounded = @interface.ReadFromMemory(0x806B) == 0;
 
-                if (grounded)
+                if (grounded && _route.Count > 0)
                 {
                     _move = _route.Dequeue();
                 }
@@ -132,7 +136,7 @@ public class WillyBot : IProcessorHook
 
     private void StartLevel(Interface @interface)
     {
-        _routePlanner = new RoutePlanner(_level, @interface);
+        _routePlanner = new RoutePlanner(_level, @interface, GetDeathCells(_level));
         
         _routePlanner.Initialise();
         
@@ -142,7 +146,47 @@ public class WillyBot : IProcessorHook
     private void RestartLevel()
     {
         _route.Clear();
-        
-        _routePlanner.GetNextRoute().ForEach(m => _route.Enqueue(m));
+
+        var route = _routePlanner.GetNextRoute();
+
+        if (route == null)
+        {
+            return;
+        }
+
+        route.ForEach(m => _route.Enqueue(m));
+    }
+
+    private void LearnFromDeath(Interface @interface)
+    {
+        var cellPointer = @interface.ReadFromMemory(0x806C) + (@interface.ReadFromMemory(0x806D) << 8);
+
+        if (cellPointer < 0x5C00)
+        {
+            return;
+        }
+
+        var cellOffset = cellPointer - 0x5C00;
+
+        var x = cellOffset % 32;
+        var y = @interface.ReadFromMemory(0x8068) / 2 / 8;
+
+        if (!_deathsByLevel.TryGetValue(_level, out var cells))
+        {
+            cells = [];
+            _deathsByLevel[_level] = cells;
+        }
+
+        cells.Add((x, y));
+    }
+
+    private IEnumerable<(int X, int Y)> GetDeathCells(int level)
+    {
+        if (_deathsByLevel.TryGetValue(level, out var cells))
+        {
+            return cells;
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
### Motivation

- Simplify and optimize route search by replacing set-based key tracking with a compact bitmask and by tracking best costs per state to avoid re-exploration.  
- Introduce a mechanism to steer pathfinding away from recently discovered death zones by applying movement penalties.  
- Teach the bot to record where it died so subsequent planning can avoid hazardous areas.  

### Description

- Replace per-node `Keys`/`Visited` collections with a `KeyMask` bitmask, a `_keyBits` map for key-to-bit mapping, and an `_allKeysMask` to test completion, and change the priority queue node payload accordingly.  
- Add `_bestCosts` dictionary to store best-known cost per `(X,Y,KeyMask)` state and skip processing of worse-cost nodes.  
- Implement `AddKey` and update `CheckKey` to use `_keyBits`, and change `IsComplete` to accept coordinates and `KeyMask` and compare against `_allKeysMask`.  
- Add `GetDeathPenalty` and `_deathCells` support to penalize moves near recorded death cells, and wire penalties into cost calculation and enqueue priority.  
- Fix movement direction tags in `GetMoves` (use `Right`/`UpRight` where appropriate) and tidy `TryWalk`/`TryJump` whitespace and safety checks.  
- Extend `WillyBot` with `_deathsByLevel`, `LearnFromDeath` to record death cell coordinates from memory, `GetDeathCells` to provide those to `RoutePlanner` when starting a level, guard against `null` routes in restart logic, and only dequeue a move when grounded and a route exists.  

### Testing

- Built the project to validate compilation after the refactor and the build completed successfully.  
- Ran the existing automated unit/integration test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5049efbc8322aca33c173e7d6f18)